### PR TITLE
Allow option*Path to be empty

### DIFF
--- a/src/ember.selectize.js
+++ b/src/ember.selectize.js
@@ -1,4 +1,4 @@
-var get = Ember.get, set = Ember.set, isArray = Ember.isArray, typeOf = Ember.typeOf;
+var get = Ember.get, set = Ember.set, isArray = Ember.isArray, typeOf = Ember.typeOf, getWithDefault = Ember.getWithDefault;
 
 /**
  * Ember.Selectize is an Ember View that encapsulates a Selectize component.
@@ -29,10 +29,10 @@ Ember.Selectize = Ember.View.extend({
    * as it is done on Ember.Select
    */
   _valuePath : Ember.computed('optionValuePath',function(){
-    return get(this,'optionValuePath').replace(/^content\.?/, '');
+    return getWithDefault(this,'optionValuePath','').replace(/^content\.?/, '');
   }),
   _labelPath : Ember.computed('optionLabelPath',function(){
-    return get(this,'optionLabelPath').replace(/^content\.?/, '');
+    return getWithDefault(this,'optionLabelPath','').replace(/^content\.?/, '');
   }),
   
   /**

--- a/src/ember.selectize.js
+++ b/src/ember.selectize.js
@@ -14,10 +14,10 @@ Ember.Selectize = Ember.View.extend({
   tagName : 'select',
   
   /**
-   * default object paths for value and label paths
+   * overrideable object paths for value and label paths
    */
-  optionValuePath : 'content.value',
-  optionLabelPath : 'content.label',
+  optionValuePath : null,
+  optionLabelPath : null,
   
   /**
    * The array of the default plugins to load into selectize
@@ -29,10 +29,10 @@ Ember.Selectize = Ember.View.extend({
    * as it is done on Ember.Select
    */
   _valuePath : Ember.computed('optionValuePath',function(){
-    return getWithDefault(this,'optionValuePath','').replace(/^content\.?/, '');
+    return getWithDefault(this,'optionValuePath','content.value').replace(/^content\.?/, '');
   }),
   _labelPath : Ember.computed('optionLabelPath',function(){
-    return getWithDefault(this,'optionLabelPath','').replace(/^content\.?/, '');
+    return getWithDefault(this,'optionLabelPath','content.label').replace(/^content\.?/, '');
   }),
   
   /**


### PR DESCRIPTION
This supports arrays with string contents, instead of objects (i.e. `content = ['option one', 'option two']`)
