### PR TITLE
selectize.addOption() only called once for entire options array

### DIFF
--- a/src/ember.selectize.js
+++ b/src/ember.selectize.js
@@ -7,23 +7,23 @@ var get = Ember.get, set = Ember.set, isArray = Ember.isArray, typeOf = Ember.ty
 Ember.Selectize = Ember.View.extend({
   attributeBindings : ['multiple', 'placeholder','autocomplete'],
   classNames : ['ember-selectize'],
-  
+
   autocomplete:'off',
   // Allows to use prompt (like in Ember.Select) or placeholder property
   placeholder: Ember.computed.alias('prompt'),
   tagName : 'select',
-  
+
   /**
    * overrideable object paths for value and label paths
    */
   optionValuePath : null,
   optionLabelPath : null,
-  
+
   /**
    * The array of the default plugins to load into selectize
    */
   plugins: ['remove_button'],
-  
+
   /**
    * Computed properties that hold the processed paths ('content.' replacement),
    * as it is done on Ember.Select
@@ -34,32 +34,32 @@ Ember.Selectize = Ember.View.extend({
   _labelPath : Ember.computed('optionLabelPath',function(){
     return getWithDefault(this,'optionLabelPath','content.label').replace(/^content\.?/, '');
   }),
-  
+
   /**
    * This flag should be true when the element is present in the DOM and false when if isn't.
    * This helps to avoid triggering unecessary observers.
    */
   inDOM: false,
-  
+
   /**
    * Pass true to 'create' property to enable tag creation mode.
    * When active, ember-selectize will send a 'create' action to its controller when a tag is created.
-   * Alternatively, you can pass a string to 'createAction' property and 
+   * Alternatively, you can pass a string to 'createAction' property and
    * ember-selectize will activate tag creation mode send an action with that name to its controller.
    */
   create:false,
   createAction:'create',
-  
+
   didInsertElement : function() {
     var allowCreate = get(this, 'create');
     var createAction = get(this, 'createAction');
     //View is now in DOM
     this.inDOM = true;
-    
+
     //Normalize create property if createAction was set
     if(createAction && (createAction !== 'create'))
       allowCreate = true;
-    
+
     //Create Selectize's instance
     //We proxy callbacks through jQuery's 'proxy' to have the callbacks context set to 'this'
     this.$().selectize({
@@ -72,10 +72,10 @@ Ember.Selectize = Ember.View.extend({
       onItemRemove : $.proxy(this._onItemRemove, this),
       onType : $.proxy(this._onType, this)
     });
-    
+
     //Save the created selectize instance
     this.selectize = this.$()[0].selectize;
-    
+
     //Some changes to content, selection and disabled could have happened before the View was inserted into the DOM.
     //We trigger all the observers manually to account for those changes.
     this._disabledDidChange();
@@ -87,10 +87,10 @@ Ember.Selectize = Ember.View.extend({
     //Unbind observers
     this._contentWillChange();
     this._selectionWillChange();
-    
+
     //Invoke Selectize's destroy
     this.selectize.destroy();
-    
+
     //We are no longer in DOM
     this.inDOM = false;
   },
@@ -152,7 +152,7 @@ Ember.Selectize = Ember.View.extend({
         selection.removeObject(obj);
       } else if(!multiple){
         this.set('selection',null);
-      } 
+      }
     }
   },
     /**
@@ -160,7 +160,7 @@ Ember.Selectize = Ember.View.extend({
    * We need to unbind any array observers if we're in multiple selection
    */
   _selectionWillChange: Ember.beforeObserver(function() {
-    
+
     var multiple = get(this, 'multiple');
     var selection = get(this, 'selection');
     if(selection && isArray(selection) && multiple) {
@@ -178,7 +178,7 @@ Ember.Selectize = Ember.View.extend({
    */
   _selectionDidChange : Ember.observer(function() {
     if(!this.inDOM) return;
-    
+
     var multiple = get(this, 'multiple');
     var selection = get(this, 'selection');
     if (multiple) {
@@ -287,44 +287,31 @@ Ember.Selectize = Ember.View.extend({
     }
     this._selectionDidChange();
   },
-  /*
+   /*
    * Triggered after the content array changes
-   * Here we process the inserted elements
-   */
-  contentArrayDidChange : function(array, idx, removedCount, addedCount) {
-    for (var i = idx; i < idx + addedCount; i++) {
-      this.objectWasAdded(array.objectAt(i), i);
-    }
-    this._selectionDidChange();
-  },
-  /*
-   * Function that is responsible for Selectize's option inserting logic
-   * If the option is an object or Ember instance, we set an observer on the label value of it.
+   * Here we process the inserted elements. If the
+   * option is an object or Ember instance, we set an observer on the label value of it.
    * This way, we can later update the label of it.
    * Useful for dealing with objects that 'lazy load' some properties/relationships.
    */
-  objectWasAdded : function(obj, index) {
-    var data = {};
-    if(typeOf(obj) === 'object' || typeOf(obj) === 'instance'){
-      data = {
-        label : get(obj, get(this,'_labelPath')),
-        value : get(obj, get(this,'_valuePath')),
-        data : obj
-      };
-      Ember.addObserver(obj,get(this,'_labelPath'),this,'_labelDidChange');
-    } else {
-      data = {
-        label : obj,
-        value : obj,
-        data : obj
-      };
-    }
-
-    if(this.selectize){
-      this.selectize.addOption(data);
+  contentArrayDidChange : function(array, idx, removedCount, addedCount) {
+    var obj, objArray = [];
+    if (this.selectize && array && array.length) {
+      for (var i = idx; i < idx + addedCount; i++) {
+        obj = array.objectAt(i);
+        if (typeOf(obj) === 'object' || typeOf(obj) === 'instance') {
+          objArray.push({
+            value: get(obj, get(this, '_valuePath')),
+            label: get(obj, get(this, '_labelPath')),
+            data: obj
+          });
+        } else {
+          objArray.push({value: obj, label: obj, data: obj});
+        }
+      }
+      this.selectize.addOption(objArray);
       this.selectize.refreshOptions(this.selectize.isFocused && !this.selectize.isInputHidden);
     }
-    //this._selectionDidChange();
   },
   /*
    * Function that is responsible for Selectize's option removing logic
@@ -345,7 +332,7 @@ Ember.Selectize = Ember.View.extend({
    */
   _labelDidChange: function(sender, key, value, rev) {
     if(!this.selectize) return;
-    
+
     var data = {
       label : get(sender, get(this,'_labelPath')),
       value : get(sender, get(this,'_valuePath')),


### PR DESCRIPTION
I moved everything from `objectWasAdded` into `contentArrayDidChange` because it makes the plugin work faster and because `selectize.addOption()` only needed to be called once. While this works for me, I'm not confident that I haven't missed anything. If you have time, throw your suggestions my way and I'll update. Cheers!
